### PR TITLE
Fix DeepL 403: send API key as Authorization header

### DIFF
--- a/Service/Translator/Deepl/ApiClient.php
+++ b/Service/Translator/Deepl/ApiClient.php
@@ -90,7 +90,12 @@ class ApiClient
 
         $url = "https://{$apiDomain}/{$endpointBase}";
 
+        $apiKey = $this->configProvider->getDeeplApiKey($storeId);
+
         $response = $this->guzzleClient->post($url, [
+            'headers' => [
+                'Authorization' => 'DeepL-Auth-Key ' . $apiKey,
+            ],
             'form_params' => $parameters,
             'timeout' => $this->configProvider->getDeeplRequestTimeout($storeId),
         ]);

--- a/Service/Translator/Deepl/ApiParametersBuilder.php
+++ b/Service/Translator/Deepl/ApiParametersBuilder.php
@@ -116,8 +116,6 @@ class ApiParametersBuilder
         if (empty($apiKey)) {
             throw new Exception('Missing DeepL API key');
         }
-        $params['auth_key'] = $apiKey;
-
         // Add source language if specified
         $sourceLanguage = $this->configProvider->getDeeplDefaultSourceLang($storeId);
         if (!empty($sourceLanguage)) {


### PR DESCRIPTION
DeepL's API requires authentication via the Authorization header ('Authorization: DeepL-Auth-Key <key>'), not as an 'auth_key' form parameter. Remove auth_key from form params and pass the key as a header in every request.

PR Fixes connection issue with DeepL:

`bin/magento pablobae:translate --text 'text to be translated' --language 'es'`

Error: DeepL translation failed: Client error: `POST https://api-free.deepl.com/v2/translate` resulted in a `403 Forbidden` response:
{"message":"Missing Authorization header, expected 'Authorization: DeepL-Auth-Key <API key>'. You can find more info in  (truncated...)