### PR TITLE
Fix CLI command name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The extension integrates with Magento's product management interface, allowing y
 
 Use the CLI command for batch translations:
 ```bash
-bin/magento pablobae:simpleaitranslator:translate --text 'text to be translated' --language 'es'
+bin/magento pablobae:translate --text 'text to be translated' --language 'es'
 ```
 
 ### Programmatic Usage


### PR DESCRIPTION
The correct command is pablobae:translate, not
pablobae:simpleaitranslator:translate.