### PR TITLE
Fix PHP 8.4 deprecated implicit nullable type in PromptBuilder

### DIFF
--- a/Service/Translator/ChatGpt/PromptBuilder.php
+++ b/Service/Translator/ChatGpt/PromptBuilder.php
@@ -32,7 +32,7 @@ class PromptBuilder
      * @param string|null $sourceLang
  * @return array
      */
-    public function buildTranslationPrompt(string $text, string $targetLang, string $sourceLang = null): array
+    public function buildTranslationPrompt(string $text, string $targetLang, ?string $sourceLang = null): array
     {
         $systemPrompt = 'You are a professional translator. Translate the text exactly as provided, maintaining any HTML or XML tags if present. Only return the translated text without any explanations or additional content. The text to be translated should be added between /// and ///. Do not include the /// in the translation.';
 


### PR DESCRIPTION
Change `string $sourceLang = null` to `?string $sourceLang = null`.
PHP 8.4 deprecates implicitly nullable parameters.

Error Log:
[Exception]
  Deprecated Functionality: Pablobae\SimpleAiTranslator\Service\Translator\ChatGpt\PromptBuilder::buildTranslationPrompt(): Implicitly marking parameter $sourceLang as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/magento/vendor/pablobae/module-simple-ai-translator/Service/Translator/ChatGpt/PromptBuilder.php on line 35
