### PR TITLE
Fix/dynamic admin url

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The extension integrates with Magento's product management interface, allowing y
 
 Use the CLI command for batch translations:
 ```bash
-bin/magento pablobae:simpleaitranslator:translate --text 'text to be translated' --language 'es'
+bin/magento pablobae:translate --text 'text to be translated' --language 'es'
 ```
 
 ### Programmatic Usage

--- a/Service/Translator/ChatGpt/PromptBuilder.php
+++ b/Service/Translator/ChatGpt/PromptBuilder.php
@@ -32,7 +32,7 @@ class PromptBuilder
      * @param string|null $sourceLang
  * @return array
      */
-    public function buildTranslationPrompt(string $text, string $targetLang, string $sourceLang = null): array
+    public function buildTranslationPrompt(string $text, string $targetLang, ?string $sourceLang = null): array
     {
         $systemPrompt = 'You are a professional translator. Translate the text exactly as provided, maintaining any HTML or XML tags if present. Only return the translated text without any explanations or additional content. The text to be translated should be added between /// and ///. Do not include the /// in the translation.';
 

--- a/Service/Translator/Deepl/ApiClient.php
+++ b/Service/Translator/Deepl/ApiClient.php
@@ -90,7 +90,12 @@ class ApiClient
 
         $url = "https://{$apiDomain}/{$endpointBase}";
 
+        $apiKey = $this->configProvider->getDeeplApiKey($storeId);
+
         $response = $this->guzzleClient->post($url, [
+            'headers' => [
+                'Authorization' => 'DeepL-Auth-Key ' . $apiKey,
+            ],
             'form_params' => $parameters,
             'timeout' => $this->configProvider->getDeeplRequestTimeout($storeId),
         ]);

--- a/Service/Translator/Deepl/ApiParametersBuilder.php
+++ b/Service/Translator/Deepl/ApiParametersBuilder.php
@@ -116,8 +116,6 @@ class ApiParametersBuilder
         if (empty($apiKey)) {
             throw new Exception('Missing DeepL API key');
         }
-        $params['auth_key'] = $apiKey;
-
         // Add source language if specified
         $sourceLanguage = $this->configProvider->getDeeplDefaultSourceLang($storeId);
         if (!empty($sourceLanguage)) {

--- a/view/adminhtml/web/js/translator-service.js
+++ b/view/adminhtml/web/js/translator-service.js
@@ -34,14 +34,17 @@ define(['jquery'], function ($) {
 
             const formKey = $('input[name="form_key"]').val();
 
+            var adminBase = window.location.origin + '/' + window.location.pathname.split('/')[1] + '/';
+
             $.ajax({
-                url: (window.BASE_URL || '/') + 'simpletranslator/translate',
+                url: adminBase + 'simpletranslator/translate',
                 type: 'POST',
                 dataType: 'json',
                 data: {
                     text: text,
                     storeId: storeId,
-                    form_key: formKey
+                    form_key: formKey,
+                    isAjax: true
                 },
                 headers: {
                     'X-Requested-With': 'XMLHttpRequest'

--- a/view/adminhtml/web/js/translator-service.js
+++ b/view/adminhtml/web/js/translator-service.js
@@ -35,7 +35,7 @@ define(['jquery'], function ($) {
             const formKey = $('input[name="form_key"]').val();
 
             $.ajax({
-                url: '/admin/simpletranslator/translate',
+                url: (window.BASE_URL || '/') + 'simpletranslator/translate',
                 type: 'POST',
                 dataType: 'json',
                 data: {


### PR DESCRIPTION
Fix hardcoded admin URL in translator-service.js

Use window.BASE_URL instead of hardcoded '/admin/' prefix so the
AJAX request works regardless of the configured admin path.